### PR TITLE
settings.json can now also be located in the root folder of the proje…

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,11 @@ var Converter = require('./lib/converter');
 var Generator = require('./lib/datagenerator');
 
 // read settings
-global.settings = require('./settings');
+try {
+	global.settings = require('../../settings');
+} catch (err) {
+	global.settings = require('./settings');
+}
 fs.exists(settings.exportPath, function(exists) {
 	if (exists) {
 		settings.root = settings.exportPath;


### PR DESCRIPTION
With this little change the settings.json can now also be located in the root folder of the project that uses the trello-releasenotes package. So it is no longer necessary to edit the file in the node_modules folder.

If it's not in the root folder of the using project the index.js looks in the folder located in the node_module path as before.

Furthermore you should mention in the documentation that it is possible to place the template file into any folder. I use the following entry and place the file in the root folder of the project that uses the trello-releasnotes package.

```
  "template":          "../../../n-odata-server.template",
```

When I additionally set the exportPath like this

```
  "exportPath":        "./relnotes",
```

the md-files are exported to the folder `relnotes`of MY project.

With this little code-change and the two configuration settings I can update to new versions of trello-releasenotes without having to make a backup of the old folder before updating.
